### PR TITLE
Issue private message

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -115,6 +115,7 @@ model PrivateMessage {
   senderId   String
   receiverId String
   content    String
+  updatedAt  DateTime? @updatedAt
   createdAt  DateTime @default(now())
   receiver   User     @relation("userReceiver", fields: [receiverId], references: [id])
   sender     User     @relation("userSender", fields: [senderId], references: [id])

--- a/backend/src/channel/exceptions/private-message.exception.ts
+++ b/backend/src/channel/exceptions/private-message.exception.ts
@@ -26,3 +26,12 @@ export class ExceptionTryingToUpdateDateMessage extends HttpException {
     super('You are trying to update the date of a message', HttpStatus.CONFLICT)
   }
 }
+
+export class ExceptionInvalidNeedlePrivateMessage extends HttpException {
+  constructor() {
+    super(
+      'You are trying to send an invalid needle to findPrivateMessageContain',
+      HttpStatus.CONFLICT
+    )
+  }
+}

--- a/backend/src/channel/exceptions/private-message.exception.ts
+++ b/backend/src/channel/exceptions/private-message.exception.ts
@@ -26,12 +26,3 @@ export class ExceptionTryingToUpdateDateMessage extends HttpException {
     super('You are trying to update the date of a message', HttpStatus.CONFLICT)
   }
 }
-
-export class ExceptionInvalidNeedlePrivateMessage extends HttpException {
-  constructor() {
-    super(
-      'You are trying to send an invalid needle to findPrivateMessageContain',
-      HttpStatus.CONFLICT
-    )
-  }
-}

--- a/backend/src/private-message/private-message.service.spec.ts
+++ b/backend/src/private-message/private-message.service.spec.ts
@@ -6,7 +6,8 @@ import {
   ExceptionTryingToUpdatePrivateMessageID,
   ExceptionPrivateMessageYourself,
   ExceptionTryingToUpdateDateMessage,
-  ExceptionTryingToUpdateUsersId
+  ExceptionTryingToUpdateUsersId,
+  ExceptionInvalidNeedlePrivateMessage
 } from '../channel/exceptions/private-message.exception'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { cleanDataBase } from '../../test/setup-environment'
@@ -51,31 +52,32 @@ describe('PrivateMessageService', () => {
     await prismaService.$executeRaw`
       INSERT INTO
       "public"."PrivateMessage"
+      ("id", "senderId", "receiverId", "content", "updatedAt", "createdAt")
       VALUES
-      ('in1ayPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in2ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in3ayPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in4ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in5ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in6ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in7ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in8ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in9ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in10yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in11yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in12yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in13yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in14yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in15yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in16yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in17yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in18yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in19yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in20yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in21yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('in22yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('er10yPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', 'YunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', '2023-09-13 10:00:00'),
-      ('er11yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'YunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', '2023-09-13 10:00:00');`
+      ('in1ayPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in2ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in3ayPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in4ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in5ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in6ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in7ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in8ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in9ayPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in10yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in11yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in12yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in13yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in14yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in15yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in16yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in17yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in18yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in19yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in20yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in21yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('in22yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'rtjayPlUh0qtDrePkJ87t', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('er10yPlUh0qtDrePkJ87t', 'rtjayPlUh0qtDrePkJ87t', 'YunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', null, '2023-09-13 10:00:00'),
+      ('er11yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'YunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', null, '2023-09-13 10:00:00');`
 
     privateMessageData = {
       content: 'This is a wonderfull message',
@@ -122,6 +124,22 @@ describe('PrivateMessageService', () => {
       )
       expect(deletedMessage).toBeDefined
     })
+    it('should update the updatedAt', async () => {
+      const updatedata = {
+        content: 'updated content'
+      }
+      const date = new Date()
+      const updatedPrivateMessage = await privateMessageService.update(
+        'in7ayPlUh0qtDrePkJ87t',
+        updatedata
+      )
+      if (updatedPrivateMessage.updatedAt) {
+        const timeDifferenceInSeconds = Math.abs(
+          (updatedPrivateMessage.updatedAt.getTime() - date.getTime()) / 1000
+        )
+        expect(timeDifferenceInSeconds).toBeLessThanOrEqual(2)
+      }
+    })
   })
 
   describe('Test Query', () => {
@@ -156,6 +174,11 @@ describe('PrivateMessageService', () => {
         )
       expect(HistoricDiscussion.length).toStrictEqual(20)
     })
+    it('should find all message that contains the needle', async () => {
+      const foundPrivateMessage =
+        await privateMessageService.findPrivateMessageContain('Ceci')
+      expect(foundPrivateMessage?.length).toStrictEqual(24)
+    })
   })
 
   describe('Test Error', () => {
@@ -188,7 +211,7 @@ describe('PrivateMessageService', () => {
 
     it('send a message to someone who do not exist', async () => {
       await expect(
-        prismaService.$executeRaw`INSERT INTO "public"."PrivateMessage" VALUES ('er12yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'zunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', '2023-09-13 10:00:00');`
+        prismaService.$executeRaw`INSERT INTO "public"."PrivateMessage" VALUES ('er12yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'zunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', null, '2023-09-13 10:00:00');`
       ).rejects.toThrow(PrismaClientKnownRequestError)
     })
 
@@ -217,6 +240,11 @@ describe('PrivateMessageService', () => {
       await expect(
         privateMessageService.update('er10yPlUh0qtDrePkJ87t', wrongData)
       ).rejects.toThrow(ExceptionTryingToUpdateUsersId)
+    })
+    it('trying to send an empty needle to find PrivatMessage', async () => {
+      await expect(
+        privateMessageService.findPrivateMessageContain('')
+      ).rejects.toThrow(ExceptionInvalidNeedlePrivateMessage)
     })
   })
 })

--- a/backend/src/private-message/private-message.service.spec.ts
+++ b/backend/src/private-message/private-message.service.spec.ts
@@ -176,8 +176,12 @@ describe('PrivateMessageService', () => {
     })
     it('should find all message that contains the needle', async () => {
       const foundPrivateMessage =
-        await privateMessageService.findPrivateMessageContain('Ceci')
-      expect(foundPrivateMessage?.length).toStrictEqual(24)
+        await privateMessageService.findPrivateMessageContain(
+          '42tX94_NVjmzVm9QL3k4r',
+          'rtjayPlUh0qtDrePkJ87t',
+          'Ceci'
+        )
+      expect(foundPrivateMessage?.length).toStrictEqual(22)
     })
   })
 
@@ -210,9 +214,26 @@ describe('PrivateMessageService', () => {
     })
 
     it('send a message to someone who do not exist', async () => {
-      await expect(
-        prismaService.$executeRaw`INSERT INTO "public"."PrivateMessage" VALUES ('er12yPlUh0qtDrePkJ87t', '42tX94_NVjmzVm9QL3k4r', 'zunzGU-8QlEvmHk8rjNRI', 'Ceci est un supermessage', null, '2023-09-13 10:00:00');`
-      ).rejects.toThrow(PrismaClientKnownRequestError)
+      const wrongData = {
+        content: 'This is a wonderfull message',
+        createdAt: new Date(),
+        receiver: { connect: { id: '555' } },
+        sender: { connect: { id: 'rtjayPlUh0qtDrePkJ87t' } }
+      }
+      await expect(privateMessageService.create(wrongData)).rejects.toThrow(
+        PrismaClientKnownRequestError
+      )
+    })
+    it('send a message by someone who do not exist', async () => {
+      const wrongData = {
+        content: 'This is a wonderfull message',
+        createdAt: new Date(),
+        receiver: { connect: { id: 'rtjayPlUh0qtDrePkJ87t' } },
+        sender: { connect: { id: '555' } }
+      }
+      await expect(privateMessageService.create(wrongData)).rejects.toThrow(
+        PrismaClientKnownRequestError
+      )
     })
 
     it('trying to change the date of a message', async () => {
@@ -243,7 +264,11 @@ describe('PrivateMessageService', () => {
     })
     it('trying to send an empty needle to find PrivatMessage', async () => {
       await expect(
-        privateMessageService.findPrivateMessageContain('')
+        privateMessageService.findPrivateMessageContain(
+          '42tX94_NVjmzVm9QL3k4r',
+          'rtjayPlUh0qtDrePkJ87t',
+          ''
+        )
       ).rejects.toThrow(ExceptionInvalidNeedlePrivateMessage)
     })
   })

--- a/backend/src/private-message/private-message.service.spec.ts
+++ b/backend/src/private-message/private-message.service.spec.ts
@@ -6,8 +6,7 @@ import {
   ExceptionTryingToUpdatePrivateMessageID,
   ExceptionPrivateMessageYourself,
   ExceptionTryingToUpdateDateMessage,
-  ExceptionTryingToUpdateUsersId,
-  ExceptionInvalidNeedlePrivateMessage
+  ExceptionTryingToUpdateUsersId
 } from '../channel/exceptions/private-message.exception'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { cleanDataBase } from '../../test/setup-environment'
@@ -137,7 +136,7 @@ describe('PrivateMessageService', () => {
         const timeDifferenceInSeconds = Math.abs(
           (updatedPrivateMessage.updatedAt.getTime() - date.getTime()) / 1000
         )
-        expect(timeDifferenceInSeconds).toBeLessThanOrEqual(2)
+        expect(timeDifferenceInSeconds).toBeLessThanOrEqual(3)
       }
     })
   })
@@ -261,15 +260,6 @@ describe('PrivateMessageService', () => {
       await expect(
         privateMessageService.update('er10yPlUh0qtDrePkJ87t', wrongData)
       ).rejects.toThrow(ExceptionTryingToUpdateUsersId)
-    })
-    it('trying to send an empty needle to find PrivatMessage', async () => {
-      await expect(
-        privateMessageService.findPrivateMessageContain(
-          '42tX94_NVjmzVm9QL3k4r',
-          'rtjayPlUh0qtDrePkJ87t',
-          ''
-        )
-      ).rejects.toThrow(ExceptionInvalidNeedlePrivateMessage)
     })
   })
 })

--- a/backend/src/private-message/private-message.service.ts
+++ b/backend/src/private-message/private-message.service.ts
@@ -5,7 +5,8 @@ import {
   ExceptionTryingToUpdatePrivateMessageID,
   ExceptionPrivateMessageYourself,
   ExceptionTryingToUpdateDateMessage,
-  ExceptionTryingToUpdateUsersId
+  ExceptionTryingToUpdateUsersId,
+  ExceptionInvalidNeedlePrivateMessage
 } from '../channel/exceptions/private-message.exception'
 
 @Injectable()
@@ -104,6 +105,22 @@ export class PrivateMessageService {
         createdAt: 'desc'
       },
       take: 20
+    })
+  }
+
+  async findPrivateMessageContain(
+    needle: string
+  ): Promise<PrivateMessage[] | null> {
+    if (needle.length <= 0) throw new ExceptionInvalidNeedlePrivateMessage()
+    return this.prisma.privateMessage.findMany({
+      where: {
+        content: {
+          contains: needle
+        }
+      },
+      orderBy: {
+        createdAt: 'desc'
+      }
     })
   }
 }

--- a/backend/src/private-message/private-message.service.ts
+++ b/backend/src/private-message/private-message.service.ts
@@ -109,14 +109,26 @@ export class PrivateMessageService {
   }
 
   async findPrivateMessageContain(
+    idSender: string,
+    idReceiv: string,
     needle: string
   ): Promise<PrivateMessage[] | null> {
     if (needle.length <= 0) throw new ExceptionInvalidNeedlePrivateMessage()
     return this.prisma.privateMessage.findMany({
       where: {
-        content: {
-          contains: needle
-        }
+        AND: [
+          {
+            content: {
+              contains: needle
+            }
+          },
+          {
+            OR: [
+              { AND: [{ senderId: idSender }, { receiverId: idReceiv }] },
+              { AND: [{ senderId: idReceiv }, { receiverId: idSender }] }
+            ]
+          }
+        ]
       },
       orderBy: {
         createdAt: 'desc'

--- a/backend/src/private-message/private-message.service.ts
+++ b/backend/src/private-message/private-message.service.ts
@@ -5,8 +5,7 @@ import {
   ExceptionTryingToUpdatePrivateMessageID,
   ExceptionPrivateMessageYourself,
   ExceptionTryingToUpdateDateMessage,
-  ExceptionTryingToUpdateUsersId,
-  ExceptionInvalidNeedlePrivateMessage
+  ExceptionTryingToUpdateUsersId
 } from '../channel/exceptions/private-message.exception'
 
 @Injectable()
@@ -113,7 +112,6 @@ export class PrivateMessageService {
     idReceiv: string,
     needle: string
   ): Promise<PrivateMessage[] | null> {
-    if (needle.length <= 0) throw new ExceptionInvalidNeedlePrivateMessage()
     return this.prisma.privateMessage.findMany({
       where: {
         AND: [


### PR DESCRIPTION
As the issue ask :

- Fixed the protection of Sender/Receiver/PM ID
- Added a method to found messages that contains a specific content and some tests to secure it
- Some test to secure messages sent or received by inexistant user.
- Added UpdatedAt in the DB that should update each time the Update method is used. (We can only update the content of the PM)
- Norm should be ok.
- I did not check for the empty message because @kbarbry seems to say that the verification will be made in the controller's

All the tests are green and seems ok.